### PR TITLE
Emit missing `::` in assignments to namespaced constants

### DIFF
--- a/lib/unparser/emitter/assignment.rb
+++ b/lib/unparser/emitter/assignment.rb
@@ -74,7 +74,10 @@ module Unparser
           # @api private
           #
           def emit_left
-            visit(base) if base
+            if base
+              visit(base)
+              write(T_DCL)
+            end
             write(name.to_s)
           end
 

--- a/spec/integration/unparser/spike_spec.rb
+++ b/spec/integration/unparser/spike_spec.rb
@@ -225,6 +225,7 @@ describe Unparser, 'spike' do
       assert_source '@@a = 1'
       assert_source '$a = 1'
       assert_source 'CONST = 1'
+      assert_source 'Name::Spaced::CONST = 1'
     end
 
     context 'multiple' do


### PR DESCRIPTION
Thanks for the great library!
