### PR TITLE
Silence warning

### DIFF
--- a/lib/unparser/comments.rb
+++ b/lib/unparser/comments.rb
@@ -15,6 +15,7 @@ module Unparser
     def initialize(comments)
       @comments = comments.dup
       @eol_text_to_skip = nil
+      @last_range_consumed = nil
     end
 
     # Consume part or all of the node


### PR DESCRIPTION
comments.rb:49 was causing the following warning:
"warning: instance variable @last_range_consumed not initialized"
