### PR TITLE
Change adamantium dependency to only depend on the minor version

### DIFF
--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('parser',        '~> 2.0.0')
   s.add_dependency('concord',       '~> 0.1.4')
-  s.add_dependency('adamantium',    '~> 0.1.0')
+  s.add_dependency('adamantium',    '~> 0.1')
   s.add_dependency('equalizer',     '~> 0.0.7')
   s.add_dependency('abstract_type', '~> 0.0.7')
 end


### PR DESCRIPTION
This branch changes the adamantium dependency to only check the minor version. Since adamantium depends on unparser, this change is necessary to allow me to change the version to `0.2.0` while keeping the build passing.

@mbj if you could grant me commit access to unparser, that'd be great.
