### PR TITLE
Add spaces around '=' in attribute assignments

### DIFF
--- a/lib/unparser/emitter/send/attribute_assignment.rb
+++ b/lib/unparser/emitter/send/attribute_assignment.rb
@@ -14,9 +14,12 @@ module Unparser
         #
         def dispatch
           emit_receiver
-          emit_selector
+          emit_attribute
+          emit_operator
           visit_terminated(arguments.first)
         end
+
+      private
 
         # Emit receiver
         #
@@ -27,6 +30,36 @@ module Unparser
         def emit_receiver
           visit_terminated(receiver)
           write(T_DOT)
+        end
+
+        # Emit attribute
+        #
+        # @return [undefined]
+        #
+        # @api private
+        #
+        def emit_attribute
+          write(attribute_name)
+        end
+
+        # Emit assignment operator
+        #
+        # @return [undefined]
+        #
+        # @api private
+        #
+        def emit_operator
+          write(WS, T_ASN, WS)
+        end
+
+        # Return attribute name
+        #
+        # @return [String]
+        #
+        # @api private
+        #
+        def attribute_name
+          string_selector[0..-2]
         end
 
       end # AttributeAssignment

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -503,9 +503,9 @@ describe Unparser do
       assert_source '(array[i] = 1).foo'
       assert_source 'array[1..2].foo'
       assert_source '(a.attribute ||= foo).bar'
-      assert_source 'foo.bar=baz[1]'
-      assert_source 'foo.bar=(baz || foo)'
-      assert_source 'foo.bar=baz.bar'
+      assert_source 'foo.bar = baz[1]'
+      assert_source 'foo.bar = (baz || foo)'
+      assert_source 'foo.bar = baz.bar'
       assert_source 'foo << (bar * baz)'
       assert_source <<-'RUBY'
         foo ||= (a, _ = b)
@@ -596,8 +596,8 @@ describe Unparser do
 
       assert_source 'foo.bar(&baz)'
       assert_source 'foo.bar(:baz, &baz)'
-      assert_source 'foo.bar=:baz'
-      assert_source 'self.foo=:bar'
+      assert_source 'foo.bar = :baz'
+      assert_source 'self.foo = :bar'
 
       assert_source 'foo.bar(baz: boz)'
       assert_source 'foo.bar(foo, "baz" => boz)'


### PR DESCRIPTION
Hi.

This PR adds spaces around the assignment operator in attribute assignments. The `AttributeAssignment#emit_operator` method was looked up in `Emitter::Assignment`.
