### PR TITLE
Add diff-lcs dependency

### DIFF
--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('adamantium',    '~> 0.2.0')
   gem.add_dependency('equalizer',     '~> 0.0.9')
   gem.add_dependency('abstract_type', '~> 0.0.7')
+  gem.add_dependency('diff-lcs',      '~> 1.2.5')
 end


### PR DESCRIPTION
This requires 'diff/lcs'
https://github.com/mbj/unparser/blob/0add7b832328b99be0138c41448734b6b5245f22/lib/unparser/cli.rb#L5-L6

This lack brings LoadError :scream:

```
$ unparser --help                                                                                                          
/Users/sane/.anyenv/envs/rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:126:in `require': cannot load such file -- diff/lcs (LoadError)
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:126:in `require'
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/unparser-0.1.16/lib/unparser/cli.rb:5:in `<top (required)>'
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:73:in `require'
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/unparser-0.1.16/bin/unparser:8:in `<top (required)>'
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/bin/unparser:23:in `load'
        from /Users/sane/.anyenv/envs/rbenv/versions/2.1.5/bin/unparser:23:in `<main>'
```
