### PR TITLE
Takes care of emitting code from manually-built AST #39

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 13
-total_score: 674
+total_score: 669

--- a/lib/unparser/comments.rb
+++ b/lib/unparser/comments.rb
@@ -102,10 +102,8 @@ module Unparser
     # @api private
     #
     def self.source_range(node, part)
-      location = node.location
-      if location && location.respond_to?(part)
-        location.public_send(part)
-      end
+      has_part = node.respond_to?(:location) && node.location.respond_to?(part)
+      node.location.public_send(part) if has_part
     end
 
   private

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -267,6 +267,16 @@ describe Unparser do
           assert_source '{ :-@ => 1 }'
         end
       end
+
+      context 'method' do
+        meth = s(:def,
+                 :foo,
+                 s(:args,
+                   s(:arg,
+                     :x)),
+                 s(:send, s(:lvar, :x), :+, s(:int, 3)))
+        assert_generates meth, "def foo(x)\n  x + 3\nend"
+      end
     end
 
     context 'access' do


### PR DESCRIPTION
solves #39

Probably more thoughtful approach is needed here, i see a FIXME above `source_range` method [here](https://github.com/mbj/unparser/blob/master/lib/unparser/comments.rb#L91).

@mbj any thoughts?