### PR TITLE
Bump parser dependency to allow 2.2.2.1

### DIFF
--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 1.9.3'
 
-  gem.add_dependency('parser',        '~> 2.2.0.2')
+  gem.add_dependency('parser',        '~> 2.2.2', '>= 2.2.2.2')
   gem.add_dependency('procto',        '~> 0.0.2')
   gem.add_dependency('concord',       '~> 0.1.5')
   gem.add_dependency('adamantium',    '~> 0.2.0')


### PR DESCRIPTION
RuboCop 0.30.1 depends on parser 2.2.2.1, which means it can’t work in a project where unparser requires parser 2.2.0.x. This allows unparser to work with parser 2.2.2.1 (provided https://github.com/mbj/mutant/pull/312 gets merged in as well).