### PR TITLE
Split off test for regexp containing bare bytes

### DIFF
--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -189,7 +189,8 @@ describe Unparser do
 
       context 'regexp' do
         assert_terminated '/foo/'
-        assert_terminated %q(/[^-+',.\/:@[:alnum:]\[\]\x80-\xff]+/)
+        assert_terminated %q(/[\x80-\xff]+/), %w(1.9)
+        assert_terminated %q(/[^-+',.\/:@[:alnum:]\[\]]+/)
         assert_terminated '/foo#{@bar}/'
         assert_terminated '/foo#{@bar}/imx'
         assert_terminated '/#{"\x00"}/', %w(1.9)


### PR DESCRIPTION
Such a regexp is invalid from Ruby 2.0 onward.

Fix for half of the build issues for #43.