### PR TITLE
Three small fixes

### DIFF
--- a/config/rubocop.yml
+++ b/config/rubocop.yml
@@ -85,3 +85,6 @@ EmptyLinesAroundModuleBody:
 # I like my style more
 AccessModifierIndentation:
   Enabled: false
+
+MultilineOperationIndentation:
+  EnforcedStyle: indented

--- a/lib/unparser/emitter/literal/dynamic_body.rb
+++ b/lib/unparser/emitter/literal/dynamic_body.rb
@@ -83,8 +83,8 @@ module Unparser
           util = self.class
           string = node.children.first
           segment = string
-                    .gsub(REPLACEMENTS, ESCAPES)
-                    .gsub(util::DELIMITER, util::REPLACEMENT)
+            .gsub(REPLACEMENTS, ESCAPES)
+            .gsub(util::DELIMITER, util::REPLACEMENT)
           write(segment)
         end
 

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -112,29 +112,25 @@ describe Unparser do
         assert_generates '-10e10000000000', '-Float::INFINITY'
       end
 
-      # Rubies < 2.0 do not have these literals, parser can parse them
-      # but there are subtible differencies. Excluding them under those rubies.
-      if RUBY_VERSION >= '2.0'
-        context 'rational' do
-          assert_terminated '1r', %w(2.1)
-          assert_generates '1.0r', '1r', %w(2.1)
-          assert_generates '-0r', '0r', %w(2.1)
+      context 'rational' do
+        assert_terminated '1r', %w(2.1)
+        assert_generates '1.0r', '1r', %w(2.1)
+        assert_generates '-0r', '0r', %w(2.1)
 
-          assert_terminated '1.5r', %w(2.1)
-          assert_terminated '1.3r', %w(2.1)
-        end
+        assert_terminated '1.5r', %w(2.1)
+        assert_terminated '1.3r', %w(2.1)
+      end
 
-        context 'complex' do
-          %w(
-            5i
-            -5i
-            0.6i
-            -0.6i
-            1000000000000000000000000000000i
-            1ri
-          ).each do |expression|
-            assert_terminated(expression, %w(2.1))
-          end
+      context 'complex' do
+        %w(
+          5i
+          -5i
+          0.6i
+          -0.6i
+          1000000000000000000000000000000i
+          1ri
+        ).each do |expression|
+          assert_terminated(expression, %w(2.1))
         end
       end
 

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -84,16 +84,16 @@ describe Unparser do
     end
 
     context 'kwargs' do
-      assert_source <<-RUBY, %w(2.1)
+      assert_source <<-RUBY, %w(2.1 2.2)
         def foo(bar:, baz:)
         end
       RUBY
 
-      assert_source <<-RUBY, %w(2.1)
+      assert_source <<-RUBY, %w(2.1 2.2)
         foo(**bar)
       RUBY
 
-      assert_source <<-RUBY, %w(2.1)
+      assert_source <<-RUBY, %w(2.1 2.2)
         def foo(bar:, baz: "value")
         end
       RUBY
@@ -113,12 +113,12 @@ describe Unparser do
       end
 
       context 'rational' do
-        assert_terminated '1r', %w(2.1)
-        assert_generates '1.0r', '1r', %w(2.1)
-        assert_generates '-0r', '0r', %w(2.1)
+        assert_terminated '1r', %w(2.1 2.2)
+        assert_generates '1.0r', '1r', %w(2.1 2.2)
+        assert_generates '-0r', '0r', %w(2.1 2.2)
 
-        assert_terminated '1.5r', %w(2.1)
-        assert_terminated '1.3r', %w(2.1)
+        assert_terminated '1.5r', %w(2.1 2.2)
+        assert_terminated '1.3r', %w(2.1 2.2)
       end
 
       context 'complex' do
@@ -190,7 +190,7 @@ describe Unparser do
         assert_terminated '/foo#{@bar}/'
         assert_terminated '/foo#{@bar}/imx'
         assert_terminated '/#{"\x00"}/', %w(1.9)
-        assert_terminated '/#{"\u0000"}/', %w(2.0 2.1)
+        assert_terminated '/#{"\u0000"}/', %w(2.0 2.1 2.2)
         assert_terminated "/\n/"
         assert_terminated '/\n/'
         assert_terminated "/\n/x"
@@ -1090,7 +1090,7 @@ describe Unparser do
           end
         RUBY
 
-        assert_source <<-'RUBY', %w(2.1)
+        assert_source <<-'RUBY', %w(2.1 2.2)
           def foo(bar: 1)
           end
         RUBY


### PR DESCRIPTION
These are three unrelated fixes I just found lying around in my local clone of unparser:

* Restore indentation style: RuboCop supports the style unparser used, but it needs to be configured.
* Remove Ruby version guard: Generation of rational literals works fine on Ruby 1.9.3 and up.
* Allow version 2.2: Some tests were marked as 2.1 only, but not updated when 2.2 came out. They work with 2.2 as well.