### PR TITLE
Emit strings in a more idiomatic fashion

### DIFF
--- a/lib/unparser/emitter/literal/primitive.rb
+++ b/lib/unparser/emitter/literal/primitive.rb
@@ -7,10 +7,41 @@ module Unparser
 
         children :value
 
+        # Emitter for string literals
+        class String < self
+          handle :str
+
+        private
+
+          # Dispatch value
+          #
+          # @return [undefined]
+          #
+          # @api private
+          #
+          def dispatch
+            if value.include? "'"
+              # Write %()-style strings for strings with both double and single
+              # quotes
+              if value.include? '"'
+                write("%(#{value})")
+              else
+                # Write double-quoted strings for strings with single but not
+                # double quotes
+                write(value.inspect)
+              end
+            else
+              # Write single-quoted strings for strings with just double quotes
+              # or no quotes at all
+              write("'#{value}'")
+            end
+          end
+        end
+
         # Emitter for primitives based on Object#inspect
         class Inspect < self
 
-          handle :sym, :str
+          handle :sym
 
         private
 


### PR DESCRIPTION
For string literals:

- If the string contains only double quotes or no quotes at all, emit
  it using double-quotes, ie:

    `'he said "hi" to me'`

- If the string contains only single quotes, emit it using
  double-quotes, ie:

    `"you're a really good programmer"`

- If the string contains double- and single-quotes, emit it using
  `%()`-style strings, ie:

    `%(he said "you're a really good programmer" to me)`

This attempts to match the style that rubocop prefers, out-of-the-box.

Obviously there are a *lot* of tests that are going to need to be changed to get this to pass, I'm just submitting the PR to see if there's any interest in doing something like this