### PR TITLE
Emit a \ line continuation when one is used between string literals in original source

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 13
-total_score: 673
+total_score: 670

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -93,6 +93,8 @@ UtilityFunction:
   - Unparser::CLI::Source#parse
   - Unparser::NodeHelpers#n
   - Unparser::NodeHelpers#s
+  - Unparser::NodeHelpers#different_lines?
+  - Unparser::NodeHelpers#combined_source_map
   - Unparser::CLI#sources
   enabled: true
 Attribute:
@@ -134,4 +136,5 @@ LongYieldList:
   exclude:
   - Unparser::AST::LocalVariableScopeEnumerator#visit
   - Unparser::AST::LocalVariableScope#match
+  - Unparser#self.chunk_by
   enabled: true

--- a/lib/unparser.rb
+++ b/lib/unparser.rb
@@ -32,6 +32,7 @@ module Unparser
 
 end # Unparser
 
+require 'unparser/util'
 require 'unparser/buffer'
 require 'unparser/node_helpers'
 require 'unparser/preprocessor'

--- a/lib/unparser/node_helpers.rb
+++ b/lib/unparser/node_helpers.rb
@@ -21,8 +21,36 @@ module Unparser
     #
     # @api private
     #
-    def n(type, children = [])
-      Parser::AST::Node.new(type, children)
+    def n(type, children = [], properties = {})
+      Parser::AST::Node.new(type, children, properties)
+    end
+
+    # Were these nodes separated by a line break in the original source?
+    # (If in fact they were parsed from Ruby source)
+    #
+    # @param [Parser::AST::Node] first
+    # @param [Parser::AST::Node] second
+    #
+    # @return [Boolean]
+    #
+    # @api private
+    #
+    def different_lines?(first, second)
+      first.loc && second.loc && first.loc.last_line != second.loc.line
+    end
+
+    # Create a source map which covers all the source locations from all
+    # the passed nodes.
+    #
+    # @param [Array<Parser::AST::Node>] nodes
+    #
+    # @return [Parser::Source::Map]
+    #
+    # @api private
+    #
+    def combined_source_map(nodes)
+      range = nodes.map(&:loc).compact.map(&:expression).reduce(&:join)
+      Parser::Source::Map.new(range)
     end
 
   end # NodeHelpers

--- a/lib/unparser/util.rb
+++ b/lib/unparser/util.rb
@@ -1,0 +1,23 @@
+module Unparser
+  # Break `enum` into chunks by iterating over it and yielding pairs of adjacent
+  # elements. If the provided block returns a truthy value, start a new chunk.
+  #
+  # @param [Enumerable] enum
+  #
+  # @return [Array]
+  #
+  # @api private
+  #
+  def self.chunk_by(enum)
+    chunk = prev = nil
+    enum.each_with_object([]) do |obj, chunks|
+      if !chunk || yield(prev, obj)
+        chunk = [obj]
+        chunks << chunk
+      else
+        chunk << obj
+      end
+      prev = obj
+    end
+  end
+end


### PR DESCRIPTION
This makes the 'corpus' integration test pass on Mutant. It didn't before.

Ruby allows string literals to be continued on another line like this:

```ruby
    "a string" \
    "another"
```

When parser sees this, it generates 2 `str` nodes, one after the other.
Therefore, make `Unparser::Emitter::Literal::DynamicBody` generate code which uses
a line continuation when it sees 2 adjacent `str` nodes under a `dstr` node, which
were separated by a line break in the original source.

When merging string literals into new `str` nodes, retain the source map information,
so we can make intelligent decisions about things like this.

Of course, when `unparser` is used to "unparse" ASTs which were built from scratch
(not parsed from Ruby source code), then no source map information will be available.
But in many cases, an AST may originally be parsed from Ruby source, and just a few
nodes will be added, removed, or modified. So many nodes will still have source maps,
which we can exploit to retain the original code formatting as much as possible.

To this end, when canonicalizing ASTs, we should avoid "throwing away" the source maps.