### PR TITLE
Don't use parentheses around operator expressions when it is obvious they aren't needed

### DIFF
--- a/lib/unparser/constants.rb
+++ b/lib/unparser/constants.rb
@@ -27,6 +27,54 @@ module Unparser
       ** %
     )
 
+    OPERATOR_PRECEDENCE = IceNine.deep_freeze([
+      # if/unless/while/until modifiers
+      %i[and or],
+      %i[not],
+      %i[defined?],
+      # assignment
+      # rescue modifier
+      # ternary operator
+      # range creation
+      %i[||],
+      %i[&&],
+      %i[== === != =~ !~ <=>],
+      %i[< <= >= >],
+      %i[| ^],
+      %i[&],
+      %i[<< >>],
+      %i[+ -],
+      %i[* / %],
+      %i[-@],
+      %i[**],
+      %i[! ~ +@]
+    ].each_with_index.flat_map { |types, weight| types.map { |t| [ t, weight ] } }.to_h)
+
+    # The following table attempts to summarize what a hypothetical "average"
+    # Ruby programmer understands about operator precedence
+    # If our "average" programmer doesn't have any idea what the precedence
+    # of a certain operator is, it shouldn't appear in this table
+    INTUITIVE_PRECEDENCE = IceNine.deep_freeze([
+      %i[and or not defined?],
+      %i[|| && == === != =~ !~ <=>],
+      %i[< <= >= > << >>],
+      %i[+ -],
+      %i[* / %],
+      %i[-@ ! ~ +@]
+    ].each_with_index.flat_map { |types, weight| types.map { |t| [ t, weight ] } }.to_h)
+
+    # The "average" Ruby programmer will probably not be very sure about
+    # operators which have the *same* precedence in the above table.
+    # For example, they know that * binds tighter than +, but might not be
+    # sure about * and %
+    # But there are some which *everybody* understands...
+    INTUITIVE_PRECEDENCE_EQUAL = [:+, :-].freeze
+
+    OPERATOR_ASSOCIATIVITY = IceNine.deep_freeze({
+      left: %i[and or || && == === != =~ !~ <=> < <= >= > | ^ & << >> + - * / %],
+      right: %i[not -@ ** ! ~ +@]
+    }.flat_map { |side, ops| ops.map { |op| [op, side] } }.to_h)
+
     COMMENT = '#'
 
     WS       = ' '

--- a/lib/unparser/emitter/binary.rb
+++ b/lib/unparser/emitter/binary.rb
@@ -13,6 +13,22 @@ module Unparser
 
       handle(*MAP.keys)
 
+      # Test if this is a binary or unary operator expression
+      #
+      # @return [Boolean]
+      #
+      def operator?
+        true
+      end
+
+      # Return the operator used (either :and, :or, :'&&', or :'||').
+      #
+      # @return [Symbol]
+      #
+      def operator
+        MAP.fetch(node.type).to_sym
+      end
+
     private
 
       # Perform dispatch
@@ -22,9 +38,9 @@ module Unparser
       # @api private
       #
       def dispatch
-        visit(left)
+        visit_on_side(left, :left)
         write(WS, MAP.fetch(node.type), WS)
-        visit(right)
+        visit_on_side(right, :right)
       end
 
     end # Binary

--- a/lib/unparser/emitter/send.rb
+++ b/lib/unparser/emitter/send.rb
@@ -18,6 +18,22 @@ module Unparser
         effective_emitter.terminated?
       end
 
+      # Test if this is a binary or unary operator expression
+      #
+      # @return [Boolean]
+      #
+      def operator?
+        binary_operator? || unary_operator?
+      end
+
+      # If this is an operator expression, return the operator used.
+      #
+      # @return [Symbol]
+      #
+      def operator
+        operator? && selector
+      end
+
     private
 
       # Perform dispatch

--- a/lib/unparser/emitter/send/binary.rb
+++ b/lib/unparser/emitter/send/binary.rb
@@ -14,9 +14,9 @@ module Unparser
         # @api private
         #
         def dispatch
-          visit(receiver)
+          visit_on_side(receiver, :left)
           emit_operator
-          emit_right
+          visit_on_side(right_node, :right)
         end
 
         # Emit operator
@@ -37,16 +37,6 @@ module Unparser
         #
         def right_node
           children[2]
-        end
-
-        # Emit right
-        #
-        # @return [undefined]
-        #
-        # @api private
-        #
-        def emit_right
-          visit(right_node)
         end
 
       end # Binary

--- a/lib/unparser/emitter/send/unary.rb
+++ b/lib/unparser/emitter/send/unary.rb
@@ -28,7 +28,7 @@ module Unparser
             write('+')
           end
 
-          visit(receiver)
+          visit_on_side(receiver, :right)
         end
 
       end # Unary

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -517,7 +517,7 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
       assert_terminated '(1..2).max'
       assert_terminated '1..2.max'
       assert_unterminated 'a || return'
-      assert_unterminated 'foo << (bar * baz)'
+      assert_unterminated 'foo << bar * baz'
 
       assert_source <<-'RUBY'
         foo ||= (a, _ = b)
@@ -1357,6 +1357,23 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
       assert_source '(a + b) / (c - d)'
       assert_source '(a + b) / c.-(e, f)'
       assert_source '(a + b) / c.-(*f)'
+      assert_source 'a + b + c'
+      assert_source 'a * b * c'
+      assert_source 'a / b / c'
+      assert_source 'a * b + c'
+      assert_source 'a + b * c'
+      assert_source 'a + (b + c)'
+      assert_generates '(a + b) + c', 'a + b + c'
+      assert_generates '(a * b) * c', 'a * b * c'
+      # ** is hi-precedence, so parens are not needed, but not everyone knows that
+      assert_source '(a ** b) + c'
+      assert_source 'a + (b ** c)'
+      assert_source 'a ** (b + c)'
+      assert_source 'a + b == c'
+      assert_source 'x > 5 && y > 10'
+      assert_source 'a + b - c + d - e'
+      assert_source '~a / -b'
+      assert_source '(str << "suffix") > "something"'
     end
 
     context 'binary operator' do
@@ -1365,7 +1382,12 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
       assert_source 'a || (break foo)'
       assert_source '(break foo) || a'
       assert_source '(a || b).foo'
-      assert_source 'a || (b || c)'
+      assert_source 'a || b || c'
+      assert_source 'a && b && c'
+      assert_generates 'a and b and c', 'a && b && c'
+      assert_generates 'a or b or c', 'a || b || c'
+      assert_generates '(a and b) or c', '(a && b) || c'
+      assert_generates 'a and (b or c)', 'a && (b || c)'
     end
 
     { or: :'||', and: :'&&' }.each do |word, symbol|
@@ -1485,13 +1507,14 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
 
     context 'unary operators' do
       assert_source '!1'
-      assert_source '!(!1)'
-      assert_source '!(!(foo || bar))'
+      assert_source '!!1'
+      assert_source '!!(foo || bar)'
       assert_source '!(!1).baz'
       assert_source '~a'
       assert_source '-a'
       assert_source '+a'
       assert_source '-(-a).foo'
+      assert_generates 'defined? a or not b', 'defined?(a) || !b'
     end
 
     context 'loop' do


### PR DESCRIPTION
To do this, we have to take operator precedence and associativity into account,
to make sure we don't change the meaning of an expression by omitting the parens.
More then that, we need to consider what precedence rules are "obvious" to an
average Ruby programmer. In many cases, parens are not strictly necessary,
but may make the meaning clearer.

On the other hand, if we *always* emit parens, the code becomes littered with
parens which are obviously redundant, and that sucks.

@mbj, I'm sure there may be better ways to implement some parts of this PR.
Please have a look and share any suggestions!