### PR TITLE
[WIP] Allow running along parser 2.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Unparser currently successfully round trips almost all ruby code around. Using M
 If there is a non round trippable example that is NOT subjected to known [Limitations](#limitations).
 please report a bug.
 
-On CI unparser is currently tested against rubyspec with minor [excludes](https://github.com/mbj/unparser/blob/master/spec/integrations.yml).
+On CI unparser is currently tested against The Ruby Spec Suite with minor [excludes](https://github.com/mbj/unparser/blob/master/spec/integrations.yml).
 
 Limitations:
 ------------

--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 13
-total_score: 670
+total_score: 668

--- a/config/reek.yml
+++ b/config/reek.yml
@@ -93,6 +93,8 @@ UtilityFunction:
   - Unparser::CLI::Source#parse
   - Unparser::NodeHelpers#n
   - Unparser::NodeHelpers#s
+  - Unparser::NodeHelpers#different_lines?
+  - Unparser::NodeHelpers#combined_source_map
   - Unparser::CLI#sources
   enabled: true
 Attribute:
@@ -134,4 +136,5 @@ LongYieldList:
   exclude:
   - Unparser::AST::LocalVariableScopeEnumerator#visit
   - Unparser::AST::LocalVariableScope#match
+  - Unparser#self.chunk_by
   enabled: true

--- a/lib/unparser.rb
+++ b/lib/unparser.rb
@@ -32,6 +32,7 @@ module Unparser
 
 end # Unparser
 
+require 'unparser/util'
 require 'unparser/buffer'
 require 'unparser/node_helpers'
 require 'unparser/preprocessor'

--- a/lib/unparser/emitter/literal/dynamic_body.rb
+++ b/lib/unparser/emitter/literal/dynamic_body.rb
@@ -40,7 +40,11 @@ module Unparser
         # @api private
         #
         def dispatch
-          children.each(&method(:emit_segment))
+          # 2 adjacent str nodes may indicate that there was a line continuation
+          # in the original source
+          children.reduce(nil) do |previous, current|
+            emit_segment(current, previous)
+          end
         end
 
         # Emit segment
@@ -51,12 +55,20 @@ module Unparser
         #
         # @api private
         #
-        def emit_segment(node)
+        def emit_segment(node, prev_node)
           if node.type == :str
+            if prev_node && prev_node.type == :str &&
+               different_lines?(prev_node, node)
+              # emit line continuation
+              write('"' + WS + '\\')
+              nl
+              write('"')
+            end
             emit_str_segment(node)
-            return
+          else
+            emit_interpolated_segment(node)
           end
-          emit_interpolated_segment(node)
+          node
         end
 
         pairs = Parser::Lexer::ESCAPES.invert.map do |key, value|

--- a/lib/unparser/node_helpers.rb
+++ b/lib/unparser/node_helpers.rb
@@ -21,8 +21,36 @@ module Unparser
     #
     # @api private
     #
-    def n(type, children = [])
-      Parser::AST::Node.new(type, children)
+    def n(type, children = [], properties = {})
+      Parser::AST::Node.new(type, children, properties)
+    end
+
+    # Were these nodes separated by a line break in the original source?
+    # (If in fact they were parsed from Ruby source)
+    #
+    # @param [Parser::AST::Node] first
+    # @param [Parser::AST::Node] second
+    #
+    # @return [Boolean]
+    #
+    # @api private
+    #
+    def different_lines?(first, second)
+      first.loc && second.loc && first.loc.last_line != second.loc.line
+    end
+
+    # Create a source map which covers all the source locations from all
+    # the passed nodes.
+    #
+    # @param [Array<Parser::AST::Node>] nodes
+    #
+    # @return [Parser::Source::Map]
+    #
+    # @api private
+    #
+    def combined_source_map(nodes)
+      range = nodes.map(&:loc).compact.map(&:expression).reduce(&:join)
+      Parser::Source::Map.new(range)
     end
 
   end # NodeHelpers

--- a/lib/unparser/util.rb
+++ b/lib/unparser/util.rb
@@ -1,0 +1,23 @@
+module Unparser
+  # Break `enum` into chunks by iterating over it and yielding pairs of adjacent
+  # elements. If the provided block returns a truthy value, start a new chunk.
+  #
+  # @param [Enumerable] enum
+  #
+  # @return [Array]
+  #
+  # @api private
+  #
+  def self.chunk_by(enum)
+    chunk = prev = nil
+    enum.each_with_object([]) do |obj, chunks|
+      if !chunk || yield(prev, obj)
+        chunk = [obj]
+        chunks << chunk
+      else
+        chunk << obj
+      end
+      prev = obj
+    end
+  end
+end

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -12,7 +12,7 @@
   repo_uri: 'https://github.com/ahawkins/chassis.git'
   exclude: []
 - name: rubyspec
-  repo_uri: 'https://github.com/rubyspec/rubyspec.git'
+  repo_uri: 'https://github.com/ruby/spec.git'
   exclude:
     # Binary encoded source subjected to limitations see Readme
     - core/array/pack/{b,h,u}_spec.rb

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -35,3 +35,9 @@
     - core/string/unpack/shared/integer.rb
     - core/symbol/casecmp_spec.rb
     - optional/capi/integer_spec.rb
+    - language/regexp/escapes_spec.rb
+    - library/conditionvariable/broadcast_spec.rb
+    - library/conditionvariable/signal_spec.rb
+    - library/zlib/deflate/deflate_spec.rb
+    - library/zlib/gzipwriter/write_spec.rb
+    - library/zlib/inflate/inflate_spec.rb

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('equalizer',     '~> 0.0.9')
   gem.add_dependency('diff-lcs',      '~> 1.2.5')
   gem.add_dependency('concord',       '~> 0.1.5')
-  gem.add_dependency('parser',        '~> 2.2.2')
+  gem.add_dependency('parser',        '>= 2.2.2', '< 2.4')
   gem.add_dependency('procto',        '~> 0.0.2')
 
   gem.add_development_dependency('anima',    '~> 0.3.0')


### PR DESCRIPTION
This allows unparser to work with parser 2.2 and 2.3 (while keeping 2.2.2+ requirement). Fixes #59.