### PR TITLE
Avoid minor version dependencies in gemspec

### DIFF
--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency('anima',    '~> 0.3')
   gem.add_development_dependency('devtools', '~> 0.1')
-  gem.add_development_dependency('morpher',  '~> 0.2')
+  gem.add_development_dependency('morpher',  '~> 0.2.5')
 end

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -17,15 +17,15 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_dependency('abstract_type', '~> 0.0.7')
-  gem.add_dependency('adamantium',    '~> 0.2.0')
-  gem.add_dependency('equalizer',     '~> 0.0.9')
-  gem.add_dependency('diff-lcs',      '~> 1.2.5')
-  gem.add_dependency('concord',       '~> 0.1.5')
-  gem.add_dependency('parser',        '~> 2.2.2')
-  gem.add_dependency('procto',        '~> 0.0.2')
+  gem.add_dependency('abstract_type', '~> 0.0')
+  gem.add_dependency('adamantium',    '~> 0.2')
+  gem.add_dependency('equalizer',     '~> 0.0')
+  gem.add_dependency('diff-lcs',      '~> 1.2')
+  gem.add_dependency('concord',       '~> 0.1')
+  gem.add_dependency('parser',        '~> 2.2')
+  gem.add_dependency('procto',        '~> 0.0')
 
-  gem.add_development_dependency('anima',    '~> 0.3.0')
-  gem.add_development_dependency('devtools', '~> 0.1.1')
-  gem.add_development_dependency('morpher',  '~> 0.2.5')
+  gem.add_development_dependency('anima',    '~> 0.3')
+  gem.add_development_dependency('devtools', '~> 0.1')
+  gem.add_development_dependency('morpher',  '~> 0.2')
 end


### PR DESCRIPTION
Dependencies like `~> x.y.z` are not recommended to use in gemspec because they cause version conflicts like in screenshot. Use `~> x.y` instead. Due to [semantic versioning](http://semver.org/) this won't break the gem because new features aren't released in patch versions of gems.

![screenshot from 2016-01-23 22 38 19](https://cloud.githubusercontent.com/assets/12196693/12532336/87dcd860-c209-11e5-9459-512fb79c640d.png)