### PR TITLE
don't require all ruby parsers when loading unparser

### DIFF
--- a/lib/unparser.rb
+++ b/lib/unparser.rb
@@ -2,7 +2,6 @@ require 'set'
 require 'abstract_type'
 require 'procto'
 require 'concord'
-require 'parser/all'
 require 'parser/current'
 
 # Library namespace

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'parser/all'
 
 describe Unparser, mutant_expression: 'Unparser::Emitter*' do
   describe '.unparse' do


### PR DESCRIPTION
On my system, loading unparser in a rails app takes about 16 MiB at boot

```
  unparser: 16.5391 MiB
    parser/all: 15.418 MiB
      parser/ruby18: 4.4492 MiB
      parser/ruby19: 4.1523 MiB
      parser/ruby20: 3.0742 MiB
      parser/ruby22: 1.5313 MiB
      parser/ruby23: 1.1055 MiB (Also required by: parser/current)
      parser/ruby21: 0.5547 MiB
      parser/ruby24: 0.5469 MiB
    concord: 0.9219 MiB
      adamantium: 0.8398 MiB
        ice_nine: 0.3945 MiB
```

If we drop parser/all, we also drop 10 MiB at boot. 🎉 

```
  unparser: 6.5898 MiB
    parser/current: 4.625 MiB
      parser/ruby23: 4.6094 MiB
    concord: 0.668 MiB
      adamantium: 0.6602 MiB
        ice_nine: 0.4102 MiB
```


Since we only use parser current, in the tests how do we feel not loading the other parsers?