### PR TITLE
Suppress Ruby 2.4 Fixnum deprecation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,7 +7,7 @@ PATH
       concord (~> 0.1.5)
       diff-lcs (~> 1.3)
       equalizer (~> 0.0.9)
-      parser (~> 2.3.0)
+      parser (>= 2.3.1.2, < 2.5)
       procto (~> 0.0.2)
 
 GEM

--- a/lib/unparser/emitter/literal/primitive.rb
+++ b/lib/unparser/emitter/literal/primitive.rb
@@ -33,12 +33,21 @@ module Unparser
 
           RATIONAL_FORMAT = 'i'.freeze
 
-          MAP = IceNine.deep_freeze(
-            Float    => :float,
-            Rational => :rational,
-            Fixnum   => :int,
-            Bignum   => :int
-          )
+          MAP =
+            if 0.class.equal?(Integer)
+              IceNine.deep_freeze(
+                Float    => :float,
+                Rational => :rational,
+                Integer  => :int
+              )
+            else
+              IceNine.deep_freeze(
+                Float    => :float,
+                Rational => :rational,
+                Fixnum   => :int,
+                Bignum   => :int
+              )
+            end
 
         private
 

--- a/spec/integrations.yml
+++ b/spec/integrations.yml
@@ -20,6 +20,7 @@
   # Revision of rubyspec on the last CI build of unparser that passed
   repo_ref: 'origin/master'
   exclude:
+    - command_line/fixtures/bad_syntax.rb
     - core/array/pack/shared/float.rb
     - core/array/pack/shared/integer.rb
     - core/array/pack/shared/string.rb
@@ -79,4 +80,3 @@
     - library/stringscanner/shared/get_byte.rb
     - library/zlib/inflate/set_dictionary_spec.rb
     - optional/capi/integer_spec.rb
-

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('equalizer',     '~> 0.0.9')
   gem.add_dependency('diff-lcs',      '~> 1.3')
   gem.add_dependency('concord',       '~> 0.1.5')
-  gem.add_dependency('parser',        '~> 2.3.0')
+  gem.add_dependency('parser',        '>= 2.3.1.2', '< 2.5')
   gem.add_dependency('procto',        '~> 0.0.2')
 
   gem.add_development_dependency('anima',    '~> 0.3.0')


### PR DESCRIPTION
I would like to update unparser to work with Ruby 2.4. I need to update devtools and mutant, since we have quite a complex dependency around here. 

I need to relax parser dependency so, I can update mutant to have relaxed dependency as well. When I will be able to install parser 2.4 I will be able to add a handler for multiple assignments AST nodes.