### PR TITLE
Fix single `arg` in nested `mlhs` block args

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 13
-total_score: 659
+total_score: 657

--- a/lib/unparser/emitter/assignment.rb
+++ b/lib/unparser/emitter/assignment.rb
@@ -144,7 +144,7 @@ module Unparser
 
       private
 
-        NO_COMMA = [:splat, :restarg].to_set.freeze
+        NO_COMMA = [:arg, :splat, :restarg].to_set.freeze
         PARENT_MLHS = [:mlhs, :masgn].freeze
 
         # Perform dispatch

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -534,6 +534,12 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
       RUBY
 
       assert_source <<-'RUBY'
+        foo.bar do |((a))|
+          d
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
         foo.bar do |(a, b), c|
           d
         end


### PR DESCRIPTION
fixes this fairly edge-casey bug:

```ruby
str = "[1, 2].map { |((e))| e * 2 }"
eval(str) # => [2, 4]

ast = Parser::CurrentRuby.parse(str)
res = Unparser.unparse(ast) # => "[1, 2].map { |((e,))| e * 2 }"
eval(res) # => SyntaxError
```
