### PR TITLE
Correct documentation; add_option takes a OptionParser

### DIFF
--- a/lib/unparser/cli.rb
+++ b/lib/unparser/cli.rb
@@ -58,7 +58,7 @@ module Unparser
 
     # Add options
     #
-    # @param [Optparse::Builder] builder
+    # @param [OptionParser] builder
     #
     # @return [undefined]
     #


### PR DESCRIPTION
The documentation for `Unparser::CLI#add_option` was slightly wrong; it listed `builder` as `Optparse::Builder`, which is a class that doesn't exist in a module that doesn't exist. This confused me as I was looking for a gem called `Optparse`.

Going back to the `add_option` method, I see it is called from `initialized` in the following block:

https://github.com/mbj/unparser/blob/7d22ef2b4482d7673b88c876d08b28c0861ebfb9/lib/unparser/cli.rb#L48-L50

Checking the class of `builder` lets conclude that it is a `OptionParser`.

```ruby
require("optparse")

OptionParser.new { |builder| puts builder.class }
"OptionParser"
```

The doc will now reflect this