### PR TITLE
Support ruby 2.5 block rescue syntax

### DIFF
--- a/config/flay.yml
+++ b/config/flay.yml
@@ -1,3 +1,3 @@
 ---
 threshold: 13
-total_score: 632
+total_score: 633

--- a/lib/unparser/emitter/rescue.rb
+++ b/lib/unparser/emitter/rescue.rb
@@ -12,7 +12,7 @@ module Unparser
 
       define_group :rescue_bodies, 1..-2
 
-      EMBEDDED_TYPES = %i[def defs kwbegin ensure].to_set.freeze
+      EMBEDDED_TYPES = %i[block def defs kwbegin ensure].to_set.freeze
 
       NOINDENT_STANDALONE_RESCUE = %i[root begin pair_rocket pair_colon lvasgn ivasgn].to_set.freeze
 

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -859,6 +859,81 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
         end
       RUBY
 
+      assert_source <<-'RUBY'
+        m do
+        rescue Exception => e
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+        ensure
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+        rescue
+        ensure
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          foo
+        rescue Exception => bar
+          bar
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          bar
+        rescue SomeError, *bar
+          baz
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          bar
+        rescue SomeError, *bar => exception
+          baz
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          bar
+        rescue *bar
+          baz
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          bar
+        rescue LoadError
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          bar
+        rescue
+        else
+          baz
+        end
+      RUBY
+
+      assert_source <<-'RUBY'
+        m do
+          bar
+        rescue *bar => exception
+          baz
+        end
+      RUBY
+
       assert_source 'foo rescue bar'
       assert_source 'foo rescue return bar'
       assert_source 'x = (foo rescue return bar)'


### PR DESCRIPTION
Prior to this commit, unparser would emit incorrect source representations for users using the new ruby 2.5 block syntax for rescue/ensure.

Round-tripping

```ruby
m do
  foo
  bar
rescue
  baz
end
```

would produce

```ruby
m do
  foo
  bar rescue baz
end
```

instead of the original source as it should.
