### PR TITLE
Upgrade parser dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/unparser
   docker:
-    - image: circleci/ruby:2.5.3
+    - image: circleci/ruby:2.5.5
 version: 2
 jobs:
   unit_specs:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,7 +28,7 @@ PATH
       concord (~> 0.1.5)
       diff-lcs (~> 1.3)
       equalizer (~> 0.0.9)
-      parser (~> 2.6.0)
+      parser (~> 2.6.2)
       procto (~> 0.0.2)
 
 GEM
@@ -104,7 +104,7 @@ GEM
       ice_nine (~> 0.11.0)
       procto (~> 0.0.2)
     parallel (1.13.0)
-    parser (2.6.0.0)
+    parser (2.6.2.0)
       ast (~> 2.4.0)
     path_expander (1.0.3)
     powerpack (0.1.2)

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('equalizer',     '~> 0.0.9')
   gem.add_dependency('diff-lcs',      '~> 1.3')
   gem.add_dependency('concord',       '~> 0.1.5')
-  gem.add_dependency('parser',        '~> 2.6.0')
+  gem.add_dependency('parser',        '~> 2.6.2')
   gem.add_dependency('procto',        '~> 0.0.2')
 
   gem.add_development_dependency('anima',    '~> 0.3.1')


### PR DESCRIPTION
Recently, `parser` 2.6.2 came out with support for recently released Ruby 2.5.5