### PR TITLE
README: Drop defunct badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ unparser
 ========
 
 [![Build Status](https://secure.travis-ci.org/mbj/unparser.png?branch=master)](http://travis-ci.org/mbj/unparser)
-[![Dependency Status](https://gemnasium.com/mbj/unparser.png)](https://gemnasium.com/mbj/unparser)
 [![Code Climate](https://codeclimate.com/github/mbj/unparser.png)](https://codeclimate.com/github/mbj/unparser)
 [![Gem Version](https://img.shields.io/gem/v/unparser.svg)](https://rubygems.org/gems/unparser)
 


### PR DESCRIPTION
This PR drops a defunct badge from the README.