### PR TITLE
Handle endless ranges

### DIFF
--- a/lib/unparser/emitter/literal/range.rb
+++ b/lib/unparser/emitter/literal/range.rb
@@ -27,7 +27,7 @@ module Unparser
         def dispatch
           visit(begin_node)
           write(TOKENS.fetch(node.type))
-          visit(end_node)
+          visit(end_node) unless end_node.nil?
         end
 
       end # Range


### PR DESCRIPTION
Ruby version: 2.6.3
Unparser: 0.4.5
Parser: 2.6.3

This patch fixes the following error:

```ruby
Unparser.unparse(Parser::CurrentRuby.parse("r = (1..)"))
#=> NoMethodError: undefined method `type' for nil:NilClass
```

Couldn't find a quick way to add tests for this change 🤷🏻‍♂️ (has been used and tests [here](https://github.com/ruby-next/ruby-next/blob/master/lib/ruby-next/language/unparser.rb)).
