### PR TITLE
Raise specific error when node is unknown

### DIFF
--- a/lib/unparser/emitter.rb
+++ b/lib/unparser/emitter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Unparser
+  UnknownEmitterError = Class.new(ArgumentError)
 
   # Emitter base class
   #
@@ -116,7 +117,7 @@ module Unparser
     def self.emitter(node, parent)
       type = node.type
       klass = REGISTRY.fetch(type) do
-        raise ArgumentError, "No emitter for node: #{type.inspect}"
+        raise UnknownEmitterError, "No emitter for node: #{type.inspect}"
       end
       klass.new(node, parent)
     end


### PR DESCRIPTION
Raise Unparser specific error instead of a general ArgumentError to make it easier to catch.

See also https://github.com/ruby-next/ruby-next/pull/47#discussion_r437208600