### PR TITLE
Change to raise unparser specific error on unknown node type

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 # v0.4.8 unreleased
 
+* Change to specific node type when unparser fails on an unknown node type: [#150](https://github.com/mbj/unparser/pull/150)
 * Significantly improve verifier (only useful for debugging)
 * Add `Unparser::Color` module for colorized source diffs
 

--- a/lib/unparser/emitter.rb
+++ b/lib/unparser/emitter.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Unparser
+  UnknownNodeError = Class.new(ArgumentError)
 
   # Emitter base class
   #
@@ -116,7 +117,7 @@ module Unparser
     def self.emitter(node, parent)
       type = node.type
       klass = REGISTRY.fetch(type) do
-        raise ArgumentError, "No emitter for node: #{type.inspect}"
+        raise UnknownNodeError, "Unknown node type: #{type.inspect}"
       end
       klass.new(node, parent)
     end

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -120,6 +120,23 @@ describe Unparser, mutant_expression: 'Unparser::Emitter*' do
   end
 
   describe '.unparse' do
+    context 'on unknown node type' do
+      def apply
+        Unparser.unparse(node)
+      end
+
+      let(:node) { s(:example_node) }
+
+      it 'raises UnknownNodeError' do
+        expect { apply }.to raise_error(
+          Unparser::UnknownNodeError,
+          'Unknown node type: :example_node'
+        )
+      end
+    end
+  end
+
+  describe '.unparse' do
     let(:builder_options) { {} }
 
     def parser


### PR DESCRIPTION
* This unparser specific exception type makes it easy to catch errors
  originating from the specific case unparser is exposed to a node type
  it does not understand.