### PR TITLE
FIX: Emit new line if `in_pattern` has no body

### DIFF
--- a/lib/unparser/emitter/in_pattern.rb
+++ b/lib/unparser/emitter/in_pattern.rb
@@ -27,6 +27,8 @@ module Unparser
           ws
           write('then')
           emit_body(branch)
+        else
+          nl
         end
       end
     end # InPattern


### PR DESCRIPTION
Example code producing a syntax error after parse->unparse:

```ruby
case v
in 1
in 2
  true
end
```

Without the fix it becomes:

```ruby
case v
in 1in 2 then
  true
end
```