### PR TITLE
Fix crash on binary operator selector with kwargs argument

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    unparser (0.6.0)
+    unparser (0.6.1)
       diff-lcs (~> 1.3)
       parser (>= 3.0.0)
 
@@ -15,14 +15,14 @@ GEM
   specs:
     ast (2.4.2)
     diff-lcs (1.4.4)
-    mutant (0.11.0)
+    mutant (0.11.1)
       diff-lcs (~> 1.3)
       parser (~> 3.0.0)
       regexp_parser (~> 2.0, >= 2.0.3)
       sorbet-runtime (~> 0.5.0)
       unparser (~> 0.6.0)
-    mutant-rspec (0.11.0)
-      mutant (= 0.11.0)
+    mutant-rspec (0.11.1)
+      mutant (= 0.11.1)
       rspec-core (>= 3.8.0, < 4.0.0)
     parallel (1.21.0)
     parser (3.0.2.0)
@@ -60,16 +60,16 @@ GEM
     rubocop-packaging (0.5.1)
       rubocop (>= 0.89, < 2.0)
     ruby-progressbar (1.11.0)
-    sorbet-runtime (0.5.9265)
+    sorbet-runtime (0.5.9307)
     unicode-display_width (2.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  mutant (~> 0.11.0)
+  mutant (~> 0.11.1)
   mutant-license!
-  mutant-rspec (~> 0.11.0)
+  mutant-rspec (~> 0.11.1)
   rspec (~> 3.9)
   rspec-core (~> 3.9)
   rspec-its (~> 1.3.0)

--- a/lib/unparser/node_details/send.rb
+++ b/lib/unparser/node_details/send.rb
@@ -19,7 +19,10 @@ module Unparser
       end
 
       def binary_syntax_allowed?
-        selector_binary_operator? && arguments.one? && !n_splat?(arguments.first)
+        selector_binary_operator?        \
+          && arguments.one?              \
+          && !n_splat?(arguments.first)  \
+          && !n_kwargs?(arguments.first)
       end
 
       def selector_unary_operator?

--- a/lib/unparser/node_helpers.rb
+++ b/lib/unparser/node_helpers.rb
@@ -36,18 +36,20 @@ module Unparser
       args
       array
       array_pattern
-      empty_else
       begin
       block
       cbase
       const
       dstr
+      empty_else
       ensure
       hash
       hash_pattern
       if
       in_pattern
       int
+      kwarg
+      kwargs
       kwsplat
       lambda
       match_rest

--- a/test/corpus/literal/send.rb
+++ b/test/corpus/literal/send.rb
@@ -68,6 +68,8 @@ foo.bar(foo, {})
 foo.bar({ foo: boz }, boz)
 foo.bar=:baz
 foo(a: b)
+foo.&(a: b)
+foo.&(**a)
 foo[*baz]
 foo[1, 2]
 foo[]

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |gem|
   gem.name        = 'unparser'
-  gem.version     = '0.6.0'
+  gem.version     = '0.6.1'
 
   gem.authors     = ['Markus Schirp']
   gem.email       = 'mbj@schirp-dso.com'
@@ -26,8 +26,8 @@ Gem::Specification.new do |gem|
   gem.add_dependency('diff-lcs', '~> 1.3')
   gem.add_dependency('parser',   '>= 3.0.0')
 
-  gem.add_development_dependency('mutant',            '~> 0.11.0')
-  gem.add_development_dependency('mutant-rspec',      '~> 0.11.0')
+  gem.add_development_dependency('mutant',            '~> 0.11.1')
+  gem.add_development_dependency('mutant-rspec',      '~> 0.11.1')
   gem.add_development_dependency('rspec',             '~> 3.9')
   gem.add_development_dependency('rspec-core',        '~> 3.9')
   gem.add_development_dependency('rspec-its',         '~> 1.3.0')


### PR DESCRIPTION
* These need to be emitted regular and cannot be emitted in binary
  syntax.

[Fix #278]