### PR TITLE
Remove unused Buffer#capture_content method

### DIFF
--- a/lib/unparser/buffer.rb
+++ b/lib/unparser/buffer.rb
@@ -44,7 +44,6 @@ module Unparser
     #
     def append_without_prefix(string)
       write(string)
-      self
     end
 
     # Increase indent
@@ -77,7 +76,6 @@ module Unparser
     #
     def nl
       write(NL)
-      self
     end
 
     def root_indent
@@ -105,18 +103,6 @@ module Unparser
     #
     def content
       @content.dup.freeze
-    end
-
-    # Capture the content written to the buffer within the block
-    #
-    # @return [String]
-    #
-    # @api private
-    #
-    def capture_content
-      size_before = content.size
-      yield
-      content[size_before..]
     end
 
     # Write raw fragment to buffer

--- a/spec/unit/unparser/buffer_spec.rb
+++ b/spec/unit/unparser/buffer_spec.rb
@@ -45,21 +45,6 @@ describe Unparser::Buffer do
     it_should_behave_like 'a command method'
   end
 
-  describe '#capture_content' do
-    let(:object) { described_class.new }
-
-    it 'should capture only the content appended within the block' do
-      object.append('foo')
-      object.nl
-      object.indent
-      captured = object.capture_content do
-        object.append('bar')
-        object.nl
-      end
-      expect(captured).to eql("  bar\n")
-    end
-  end
-
   describe '#content' do
     subject { object.content }
 


### PR DESCRIPTION
- The last reference to this method I can find outside of the specs is in 189d9f468a7840bf8790129d8d00aa8be05a625a and appears to be unused since well before then.
- Also resolve some uncovered mutations since `Buffer#write` already returns `self`.