### PR TITLE
Fix {begin,end}less {i,e}range flipflops

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@
 
 * Fix crash on kwrestarg hash member
 
+[#349](https://github.com/mbj/unparser/pull/349)
+
+* Fix {begin,end}less {i,e}range flipflops
+
 # v0.6.8 2023-06-14
 
 [#347](https://github.com/mbj/unparser/pull/347)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     unparser (0.6.9)
       diff-lcs (~> 1.3)
-      parser (>= 3.2.0)
+      parser (>= 3.2.2.4)
 
 GEM
   remote: https://oss:Px2ENN7S91OmWaD5G7MIQJi1dmtmYrEh@gem.mutant.dev/
@@ -14,25 +14,27 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    base64 (0.1.1)
     diff-lcs (1.5.0)
     json (2.6.3)
-    mutant (0.11.20)
+    language_server-protocol (3.17.0.3)
+    mutant (0.11.22)
       diff-lcs (~> 1.3)
       parser (~> 3.2.2)
       regexp_parser (~> 2.6.1)
       sorbet-runtime (~> 0.5.0)
-      unparser (~> 0.6.7)
-    mutant-rspec (0.11.20)
-      mutant (= 0.11.20)
+      unparser (~> 0.6.8)
+    mutant-rspec (0.11.22)
+      mutant (= 0.11.22)
       rspec-core (>= 3.8.0, < 4.0.0)
     parallel (1.23.0)
-    parser (3.2.2.3)
+    parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
     racc (1.7.1)
     rainbow (3.1.1)
     regexp_parser (2.6.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -45,18 +47,20 @@ GEM
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
-    rubocop (1.52.1)
+    rspec-support (3.12.1)
+    rubocop (1.56.4)
+      base64 (~> 0.1.1)
       json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.2.2.3)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.0, < 2.0)
+      rubocop-ast (>= 1.28.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.29.0)
@@ -64,16 +68,16 @@ GEM
     rubocop-packaging (0.5.2)
       rubocop (>= 1.33, < 2.0)
     ruby-progressbar (1.13.0)
-    sorbet-runtime (0.5.10878)
-    unicode-display_width (2.4.2)
+    sorbet-runtime (0.5.11064)
+    unicode-display_width (2.5.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  mutant (~> 0.11.18)
+  mutant (~> 0.11.22)
   mutant-license!
-  mutant-rspec (~> 0.11.18)
+  mutant-rspec (~> 0.11.22)
   rspec (~> 3.9)
   rspec-core (~> 3.9)
   rspec-its (~> 1.3.0)

--- a/bin/corpus
+++ b/bin/corpus
@@ -116,7 +116,7 @@ module Unparser
               puts(project.name)
             end
 
-            Kernel.exit(true)
+            Kernel.exit
           end
         end
 
@@ -148,7 +148,7 @@ module Unparser
           project.verify || Kernel.exit(false)
         end
 
-        Kernel.exit(true)
+        Kernel.exit
       end
 
     end # CLI

--- a/lib/unparser/emitter/flipflop.rb
+++ b/lib/unparser/emitter/flipflop.rb
@@ -25,9 +25,14 @@ module Unparser
     private
 
       def dispatch
-        visit(left)
+        visit(left) if left
         write(MAP.fetch(node.type))
-        visit(right)
+
+        if right
+          visit(right)
+        else
+          write(';')
+        end
       end
     end # FlipFLop
   end # Emitter

--- a/test/corpus/literal/flipflop.rb
+++ b/test/corpus/literal/flipflop.rb
@@ -4,3 +4,7 @@ end
 if ((i == 4)...(i == 4))
   foo
 end
+if ..foo
+end
+if foo..;
+end

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -26,10 +26,10 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 2.7'
 
   gem.add_dependency('diff-lcs', '~> 1.3')
-  gem.add_dependency('parser',   '>= 3.2.0')
+  gem.add_dependency('parser',   '>= 3.2.2.4')
 
-  gem.add_development_dependency('mutant',            '~> 0.11.18')
-  gem.add_development_dependency('mutant-rspec',      '~> 0.11.18')
+  gem.add_development_dependency('mutant',            '~> 0.11.22')
+  gem.add_development_dependency('mutant-rspec',      '~> 0.11.22')
   gem.add_development_dependency('rspec',             '~> 3.9')
   gem.add_development_dependency('rspec-core',        '~> 3.9')
   gem.add_development_dependency('rspec-its',         '~> 1.3.0')


### PR DESCRIPTION
* This requires to pin a parser release where this is fixed.
* And has to bump rubocop.