### PR TITLE
Avoid breaking on empty begin nodes within conditionals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: push
+on:
+  push:
+  pull_request:
 
 jobs:
   base:

--- a/lib/unparser/generation.rb
+++ b/lib/unparser/generation.rb
@@ -121,27 +121,29 @@ module Unparser
     end
 
     def emit_body(node, indent: true)
-      if indent
-        buffer.indent
-        nl
-      end
-
-      if n_begin?(node)
-        if node.children.empty?
-          write('()')
-        elsif node.children.one?
-          visit_deep(node)
+      with_indent(indent: indent) do
+        if n_begin?(node)
+          if node.children.empty?
+            write('()')
+          elsif node.children.one?
+            visit_deep(node)
+          else
+            emit_body_inner(node)
+          end
         else
-          emit_body_inner(node)
+          visit_deep(node)
         end
-      else
-        visit_deep(node)
       end
+    end
 
-      if indent
-        buffer.unindent
-        nl
-      end
+    def with_indent(indent:)
+      return yield unless indent
+
+      buffer.indent
+      nl
+      yield
+      buffer.unindent
+      nl
     end
 
     def emit_body_inner(node)

--- a/lib/unparser/generation.rb
+++ b/lib/unparser/generation.rb
@@ -127,7 +127,9 @@ module Unparser
       end
 
       if n_begin?(node)
-        if node.children.one?
+        if node.children.empty?
+          write('()')
+        elsif node.children.one?
           visit_deep(node)
         else
           emit_body_inner(node)

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -191,6 +191,7 @@ describe Unparser, mutant_expression: 'Unparser*' do
       generated = Unparser.unparse(*ast_with_comments).chomp
       expect(generated).to eql(expected)
       ast, comments = parse_with_comments(generated)
+      expect(ast).to eql(ast_with_comments.first)
       expect(Unparser.unparse(ast, comments).chomp).to eql(expected)
     end
 

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -353,6 +353,42 @@ describe Unparser, mutant_expression: 'Unparser*' do
         block comment
       =end
     RUBY
+
+    assert_generates(<<~'RUBY', <<~'RUBY')
+      true ? "true" : ()
+    RUBY
+      if true
+        "true"
+      else
+        ()
+      end
+    RUBY
+
+    assert_generates(<<~'RUBY', <<~'RUBY')
+      true ? () : "false"
+    RUBY
+      if true
+        ()
+      else
+        "false"
+      end
+    RUBY
+
+    assert_source(<<~'RUBY')
+      if true
+        "true"
+      else
+        ()
+      end
+    RUBY
+
+    assert_source(<<~'RUBY')
+      if true
+        ()
+      else
+        "false"
+      end
+    RUBY
   end
 
   describe 'corpus' do


### PR DESCRIPTION
I stumbled upon an error: 

```
NoMethodError: undefined method `type' for nil:NilClass
lib/unparser/node_helpers.rb:31:in `n?'
lib/unparser/node_helpers.rb:66:in `block (2 levels) in <module:NodeHelpers>'
lib/unparser/generation.rb:159:in `emit_body_member'
...
```

Which is produced while unparsing a snippet of code like this: 

```
'true ? "true" : ()'
'true ? () : "false"'
```

Unfortunately on the project I'm currently working I can't guarantee/rewrite incoming code snippets, so have to handle. 