### PR TITLE
Tighten Ruby version requirement to avoid `Symbol#inspect` bug in previous versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3]
+        ruby: [ruby-3.2, ruby-3.3]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3]
+        ruby: [ruby-3.2, ruby-3.3]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3]
+        ruby: [ruby-3.2, ruby-3.3]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3]
+        ruby: [ruby-3.2, ruby-3.3]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ruby-3.0, ruby-3.1, ruby-3.2, ruby-3.3]
+        ruby: [ruby-3.2, ruby-3.3]
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v3

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -390,6 +390,9 @@ describe Unparser, mutant_expression: 'Unparser*' do
         "false"
       end
     RUBY
+
+    # Test for Symbol#inspect bug: https://bugs.ruby-lang.org/issues/18905
+    assert_source(':"8 >="')
   end
 
   describe 'corpus' do

--- a/unparser.gemspec
+++ b/unparser.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
 
   gem.metadata['rubygems_mfa_required'] = 'true'
 
-  gem.required_ruby_version = '>= 3.0'
+  gem.required_ruby_version = '>= 3.2'
 
   gem.add_dependency('diff-lcs', '~> 1.3')
   gem.add_dependency('parser',   '>= 3.3.0')


### PR DESCRIPTION
Original bug:
https://bugs.ruby-lang.org/issues/18905

Resolves: https://github.com/mbj/unparser/issues/359