### PR TITLE
Add a fix for `Symbol#inspect` on `3.0`, `3.1`

### DIFF
--- a/lib/unparser/emitter/primitive.rb
+++ b/lib/unparser/emitter/primitive.rb
@@ -28,7 +28,7 @@ module Unparser
 
         # mutant:disable
         def dispatch
-          if RUBY_VERSION < '3.2' && value[-1] == '='
+          if RUBY_VERSION < '3.2' && value.match?(/=\z/)
             write(":#{value.name.inspect}")
           else
             write(value.inspect)

--- a/lib/unparser/emitter/primitive.rb
+++ b/lib/unparser/emitter/primitive.rb
@@ -10,19 +10,31 @@ module Unparser
       # Emitter for primitives based on Object#inspect
       class Inspect < self
 
-        handle :sym, :str
+        handle :str
 
       private
 
         def dispatch
-          if RUBY_VERSION < '3.2' && node.type == :sym && value[-1] == '='
+          write(value.inspect)
+        end
+
+      end # Inspect
+
+      class Symbol < self
+
+        handle :sym
+
+        private
+
+        def dispatch
+          if RUBY_VERSION < '3.2' && value[-1] == '='
             write(":#{value.name.inspect}")
           else
             write(value.inspect)
           end
         end
 
-      end # Inspect
+      end # Symbol
 
       # Emitter for complex literals
       class Complex < self

--- a/lib/unparser/emitter/primitive.rb
+++ b/lib/unparser/emitter/primitive.rb
@@ -26,6 +26,7 @@ module Unparser
 
         private
 
+        # mutant:disable
         def dispatch
           if RUBY_VERSION < '3.2' && value[-1] == '='
             write(":#{value.name.inspect}")

--- a/lib/unparser/emitter/primitive.rb
+++ b/lib/unparser/emitter/primitive.rb
@@ -15,7 +15,11 @@ module Unparser
       private
 
         def dispatch
-          write(value.inspect)
+          if RUBY_VERSION < '3.2' && node.type == :sym && value[-1] == '='
+            write(":#{value.name.inspect}")
+          else
+            write(value.inspect)
+          end
         end
 
       end # Inspect

--- a/lib/unparser/emitter/primitive.rb
+++ b/lib/unparser/emitter/primitive.rb
@@ -28,13 +28,22 @@ module Unparser
 
         # mutant:disable
         def dispatch
-          if RUBY_VERSION < '3.2' && value.match?(/=\z/)
+          if inspect_breaks_parsing?
             write(":#{value.name.inspect}")
           else
             write(value.inspect)
           end
         end
 
+        # mutant:disable
+        def inspect_breaks_parsing?
+          return false unless RUBY_VERSION < '3.2.'
+
+          Unparser.parse(value.inspect)
+          false
+        rescue Parser::SyntaxError
+          true
+        end
       end # Symbol
 
       # Emitter for complex literals

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -390,6 +390,9 @@ describe Unparser, mutant_expression: 'Unparser*' do
         "false"
       end
     RUBY
+
+    # Test Symbol#inspect Ruby bug: https://bugs.ruby-lang.org/issues/18905
+    assert_source(':"8 >="')
   end
 
   describe 'corpus' do

--- a/spec/unit/unparser_spec.rb
+++ b/spec/unit/unparser_spec.rb
@@ -392,6 +392,8 @@ describe Unparser, mutant_expression: 'Unparser*' do
     RUBY
 
     # Test Symbol#inspect Ruby bug: https://bugs.ruby-lang.org/issues/18905
+    assert_source(':"@="')
+    assert_source(':"$$$$="')
     assert_source(':"8 >="')
   end
 


### PR DESCRIPTION
Original bug:
https://bugs.ruby-lang.org/issues/18905

Resolves: https://github.com/mbj/unparser/issues/359