### PR TITLE
Fix README `parse_with_comments` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ To preserve the comments from the source:
 require 'parser/current'
 require 'unparser'
 
-ast, comments = Unparser.parse_with_comments('your(ruby(code)) # with comments')
+ast, comments = Unparser.parser.parse_with_comments(Unparser.buffer('your(ruby(code)) # with comments'))
 
-Unparser.unparse(ast, comments) # => 'your(ruby(code)) # with comments'
+Unparser.unparse(ast, comments: comments) # => 'your(ruby(code)) # with comments'
 ```
 
 Passing in manually constructed AST:


### PR DESCRIPTION
I was playing with comments-preserving unparsing and it seems like README example uses invalid API

BTW is there a reason there's no direct `Unparser.parse_with_comments` method?