### PR TITLE
Fix regexp with gvar unparsing

### DIFF
--- a/lib/unparser/node_helpers.rb
+++ b/lib/unparser/node_helpers.rb
@@ -43,6 +43,7 @@ module Unparser
       dstr
       empty_else
       ensure
+      gvar
       hash
       hash_pattern
       if

--- a/lib/unparser/writer/regexp.rb
+++ b/lib/unparser/writer/regexp.rb
@@ -55,6 +55,9 @@ module Unparser
             write('#{')
             node.children.each(&method(:visit))
             write('}')
+          elsif n_gvar?(node)
+            write('#')
+            write_regular(node.children.first.to_s)
           else
             write_regular(node.children.first)
           end

--- a/test/corpus/literal/regexp.rb
+++ b/test/corpus/literal/regexp.rb
@@ -30,3 +30,5 @@ HEREDOC
 /
 a
 /
+/aaa #{$bbb}/
+/aaa #$bbb/


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/392

```bash
$ bundle exec bin/unparser -e '/foo #$G/'
(string)
Original-Source:
/foo #$G/
Generated-Source:
lib/unparser/buffer.rb:149:in `write'
lib/unparser/buffer.rb:55:in `append_without_prefix'
unparser/writer/regexp.rb:69:in `write_regular'
unparser/writer/regexp.rb:59:in `emit_body'
unparser/writer/regexp.rb:45:in `each'
unparser/writer/regexp.rb:45:in `block in dispatch'
```