### PR TITLE
Fix `resbody` with multiple indexes assignment unparsing

### DIFF
--- a/lib/unparser/writer/resbody.rb
+++ b/lib/unparser/writer/resbody.rb
@@ -58,10 +58,10 @@ module Unparser
       end
 
       def write_index_assignment
-        receiver, index = assignment.children
+        receiver, *indexes = assignment.children
         visit(receiver)
         write('[')
-        visit(index) if index
+        delimited(indexes)
         write(']')
       end
     end # Resbody

--- a/test/corpus/semantic/rescue.rb
+++ b/test/corpus/semantic/rescue.rb
@@ -10,4 +10,6 @@ class A
   ensure
   end
 end
-
+begin; rescue => A[1]; end
+begin; rescue => A[1, 2]; end
+begin; rescue => A[1, 2, 3]; end


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387