### PR TITLE
Fix `rescue` without body unparsing

### DIFF
--- a/lib/unparser/writer/resbody.rb
+++ b/lib/unparser/writer/resbody.rb
@@ -15,7 +15,7 @@ module Unparser
 
       def emit_postcontrol
         write(' rescue ')
-        visit(body)
+        visit(body) if body
       end
 
       def emit_regular

--- a/lib/unparser/writer/rescue.rb
+++ b/lib/unparser/writer/rescue.rb
@@ -21,7 +21,7 @@ module Unparser
       end
 
       def emit_postcontrol
-        visit(body)
+        visit(body) if body
         writer_with(Resbody, node: rescue_body).emit_postcontrol
       end
 

--- a/test/corpus/semantic/rescue.rb
+++ b/test/corpus/semantic/rescue.rb
@@ -10,6 +10,9 @@ class A
   ensure
   end
 end
+module A
+rescue
+end
 begin; rescue => A[1]; end
 begin; rescue => A[1, 2]; end
 begin; rescue => A[1, 2, 3]; end


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387