### PR TITLE
Fix negated `flipflop` unparsing

### DIFF
--- a/lib/unparser/node_helpers.rb
+++ b/lib/unparser/node_helpers.rb
@@ -31,6 +31,10 @@ module Unparser
       node.type.equal?(type)
     end
 
+    def n_flipflop?(node)
+      n_iflipflop?(node) || n_eflipflop?(node)
+    end
+
     %i[
       arg
       args
@@ -41,12 +45,14 @@ module Unparser
       cbase
       const
       dstr
+      eflipflop
       empty_else
       ensure
       gvar
       hash
       hash_pattern
       if
+      iflipflop
       in_pattern
       int
       kwarg

--- a/lib/unparser/writer/send/unary.rb
+++ b/lib/unparser/writer/send/unary.rb
@@ -14,11 +14,16 @@ module Unparser
 
         def dispatch
           name = selector
+          first_child = children.fetch(0)
 
-          write(MAP.fetch(name, name).to_s)
+          if n_flipflop?(first_child)
+            write 'not '
+          else
+            write(MAP.fetch(name, name).to_s)
 
-          if n_int?(receiver) && selector.equal?(:+@)
-            write('+')
+            if n_int?(receiver) && selector.equal?(:+@)
+              write('+')
+            end
           end
 
           visit(receiver)

--- a/test/corpus/literal/flipflop.rb
+++ b/test/corpus/literal/flipflop.rb
@@ -8,3 +8,7 @@ if ..foo
 end
 if foo..;
 end
+not foo..bar
+not foo...bar
+!(foo..bar)
+!(foo...bar)


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387

```bash
bundle exec bin/unparser -e 'not a...b'
(string)
Original-Source:
not a...b
Generated-Source:
!a...b
Original-Node:
(send
  (eflipflop
    (send nil :a)
    (send nil :b)) :!)
Generated-Node:
(erange
  (send
    (send nil :a) :!)
  (send nil :b))
Node-Diff:
@@ -1,4 +1,4 @@
-(send
-  (eflipflop
-    (send nil :a)
-    (send nil :b)) :!)
+(erange
+  (send
+    (send nil :a) :!)
+  (send nil :b))
```