### PR TITLE
Fix `not` with binary operator unparsing

### DIFF
--- a/lib/unparser/node_helpers.rb
+++ b/lib/unparser/node_helpers.rb
@@ -36,6 +36,7 @@ module Unparser
     end
 
     %i[
+      and
       arg
       args
       array
@@ -61,6 +62,7 @@ module Unparser
       lambda
       lvar
       match_rest
+      or
       pair
       rescue
       send

--- a/lib/unparser/writer/send/unary.rb
+++ b/lib/unparser/writer/send/unary.rb
@@ -12,11 +12,11 @@ module Unparser
 
         private_constant(*constants(false))
 
-        def dispatch
+        def dispatch # rubocop:disable Metrics/AbcSize
           name = selector
           first_child = children.fetch(0)
 
-          if n_flipflop?(first_child)
+          if n_flipflop?(first_child) || n_and?(first_child) || n_or?(first_child)
             write 'not '
           else
             write(MAP.fetch(name, name).to_s)

--- a/test/corpus/semantic/not.rb
+++ b/test/corpus/semantic/not.rb
@@ -1,0 +1,16 @@
+!(foo and bar)
+!(foo or bar)
+not(foo and bar)
+not(foo or bar)
+! foo and bar
+! foo or bar
+not foo and bar
+not foo or bar
+!(foo && bar)
+!(foo || bar)
+not(foo && bar)
+not(foo || bar)
+! foo && bar
+! foo || bar
+not foo && bar
+not foo || bar


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387

This solution aint perfect (there are still some bugs in this area), but at least it fixes some of them.

I'll try to find some time to revisit it later.