### PR TITLE
Fix `match-pattern-p` with logical operator unparsing

### DIFF
--- a/lib/unparser/writer/binary.rb
+++ b/lib/unparser/writer/binary.rb
@@ -39,7 +39,7 @@ module Unparser
           tANDOP: '&&'
         }.freeze
 
-      NEED_KEYWORD = %i[return break next].freeze
+      NEED_KEYWORD = %i[return break next match_pattern_p].freeze
 
       private_constant(*constants(false))
 

--- a/test/corpus/semantic/pattern.rb
+++ b/test/corpus/semantic/pattern.rb
@@ -25,3 +25,4 @@ end
 case foo
 in %q[a b c $FILE]
 end
+a in b, and c


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387

```bash
$ bundle exec bin/unparser -e 'a in b, and c'
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.3.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(string)
Original-Source:
a in b, and c
Generated-Source:
a in [b, ] && c
Original-Node:
(and
  (match-pattern-p
    (send nil :a)
    (array-pattern-with-tail
      (match-var :b)))
  (send nil :c))
Generated-Node:
```