### PR TITLE
Fix `resbody` without body unparsing

### DIFF
--- a/lib/unparser/writer/resbody.rb
+++ b/lib/unparser/writer/resbody.rb
@@ -14,8 +14,13 @@ module Unparser
       children :exception, :assignment, :body
 
       def emit_postcontrol
-        write(' rescue ')
-        visit(body) if body
+        if body
+          write(' rescue ')
+          visit(body)
+        else
+          nl
+          write('rescue')
+        end
       end
 
       def emit_regular

--- a/test/corpus/semantic/rescue.rb
+++ b/test/corpus/semantic/rescue.rb
@@ -16,3 +16,4 @@ end
 begin; rescue => A[1]; end
 begin; rescue => A[1, 2]; end
 begin; rescue => A[1, 2, 3]; end
+module A; x = 1; rescue; end


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387

```bash
$ bundle exec bin/unparser -e 'module A; x = 1; rescue; end'
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.3.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(string)
Original-Source:
module A; x = 1; rescue; end
Generated-Source:
module A
  x = 1 rescue
end

Original-Node:
(module
  (const nil :A)
  (rescue
    (lvasgn :x
      (int 1))
    (resbody nil nil nil) nil))
Generated-Node:
```