### PR TITLE
Fix mass assign and `rescue` precedence during unparsing

### DIFF
--- a/lib/unparser/emitter/assignment.rb
+++ b/lib/unparser/emitter/assignment.rb
@@ -25,6 +25,16 @@ module Unparser
 
         if BINARY_OPERATOR.include?(right.type)
           writer_with(Writer::Binary, node: right).emit_operator
+        elsif n_array?(right)
+          emit_array
+        else
+          right_emitter.write_to_buffer
+        end
+      end
+
+      def emit_array
+        if right.children.size > 1
+          delimited(right.children)
         else
           right_emitter.write_to_buffer
         end

--- a/test/corpus/literal/rescue.rb
+++ b/test/corpus/literal/rescue.rb
@@ -1,3 +1,10 @@
 foo rescue bar
 foo rescue return bar
 x = (foo rescue return bar)
+foo = [] rescue nil
+foo = 1 rescue nil
+foo = [1] rescue nil
+foo = 1, 2 rescue nil
+(foo = []) rescue nil
+(foo = 1) rescue nil
+(foo = [1]) rescue nil


### PR DESCRIPTION
Extracted from https://github.com/mbj/unparser/pull/387

```shell
$ bundle exec bin/unparser -e 'foo = 1, 2 rescue nil'
warning: parser/current is loading parser/ruby34, which recognizes 3.4.0-dev-compliant syntax, but you are running 3.4.3.
Please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
(string)
Original-Source:
foo = 1, 2 rescue nil
Generated-Source:
foo = [1, 2] rescue nil
Original-Node:
(rescue
  (lvasgn :foo
    (array
      (int 1)
      (int 2)))
  (resbody nil nil
    (nil)) nil)
Generated-Node:
(lvasgn :foo
  (rescue
    (array
      (int 1)
      (int 2))
    (resbody nil nil
      (nil)) nil))
Node-Diff:
@@ -1,7 +1,7 @@
-(rescue
-  (lvasgn :foo
+(lvasgn :foo
+  (rescue
     (array
       (int 1)
-      (int 2)))
-  (resbody nil nil
-    (nil)) nil)
+      (int 2))
+    (resbody nil nil
+      (nil)) nil))

Error: (string)
```